### PR TITLE
Tiny nitpicks

### DIFF
--- a/curl.c
+++ b/curl.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
   gettimeofday(&end, NULL);
   diff = end.tv_sec-start.tv_sec;
   us = diff * 1000000 + end.tv_usec-start.tv_usec;
-  printf("%d parsed URLs in %.1f secs, %.1f ns/URL, %.0f URLs/sec\n",
+  printf("%zu parsed URLs in %.1f secs, %.1f ns/URL, %.0f URLs/sec\n",
          count,
          (double)us/1000000.0,
          (double)us*1000/count, count / (us/1000000.0),

--- a/curl.c
+++ b/curl.c
@@ -65,16 +65,16 @@ int main(int argc, char **argv)
   while(fgets(buffer, sizeof(buffer), stdin)) {
     char *nl = strchr(buffer, '\n');
     if(nl) {
-      CURLHcode hcode;
+      CURLUcode ucode;
       *nl = 0;
       for(o = 0; options[o] != END_OF_LIST; o++) {
         CURLU *p = curl_url();
-        hcode = curl_url_set(p, CURLUPART_URL, buffer, options[o]);
+        ucode = curl_url_set(p, CURLUPART_URL, buffer, options[o]);
         curl_url_cleanup(p);
         count++;
-        if(hcode) {
+        if(ucode) {
 #if 0
-          fprintf(stderr, "Failed [%u]: %s\n", (int)hcode, buffer);
+          fprintf(stderr, "Failed [%u]: %s\n", (int)ucode, buffer);
 #endif
           ecount++;
         }

--- a/curl.c
+++ b/curl.c
@@ -87,8 +87,7 @@ int main(int argc, char **argv)
   printf("%zu parsed URLs in %.1f secs, %.1f ns/URL, %.0f URLs/sec\n",
          count,
          (double)us/1000000.0,
-         (double)us*1000/count, count / (us/1000000.0),
-         ecount);
+         (double)us*1000/count, count / (us/1000000.0));
   printf("Errors: %zu (%.2f%%)\n", ecount, (double)ecount*100/count);
   return 0;
 }


### PR DESCRIPTION
Hi Daniel,

Upon compiling curl.c I got some warnings, which this PR gets rid of. In short:

- `hcode` was declared to be of type `CURLHcode`, but `curl_url_set()` returns an `CURLUcode`. I changed the type and renamed the variable accordingly.
- `count` is `size_t`, but the string in the `printf()` call used `%d`; I changed it to `%zu`.
- `ecount` is not used in the `printf()` call on line 87, so I omitted it.

All the best,
Ole